### PR TITLE
Raw: Menu Extension

### DIFF
--- a/3/1-Introduction.md
+++ b/3/1-Introduction.md
@@ -43,7 +43,7 @@ connecting disparate systems and datasets.
         1. Wholesale
         1. Retail
         1. Consumer
-- **Seciton 3: Tables: Insights from information**
+- **Section 3: Tables: Insights from information**
     1. Toolchain
     1. Data Concerns
         1. Telemetry

--- a/3/3-Core-Structures.md
+++ b/3/3-Core-Structures.md
@@ -58,6 +58,30 @@ separately in [Part 1.2, Extension Structures](4-Extension-Structures.md).
     - [EmailAddress](#opencannabis.contact.EmailAddress)
     - [Website](#opencannabis.contact.Website)
 - `products`: High-level concrete product structures.
+    - [Merchandise](#opencannabis.products.Merchandise)
+    - [MerchandiseFlag](#opencannabis.products.MerchandiseFlag)
+    - [MerchandiseType](#opencannabis.products.MerchandiseType)
+    - [Apothecary](#opencannabis.products.Apothecary)
+    - [ApothecaryType](#opencannabis.products.ApothecaryType)
+    - [Flower](#opencannabis.products.Flower)
+    - [Edible](#opencannabis.products.Edible)
+    - [EdibleIngredient](#opencannabis.products.EdibleIngredient)
+    - [EdibleFlag](#opencannabis.products.EdibleFlag)
+    - [EdibleType](#opencannabis.products.EdibleType)
+    - [Extract](#opencannabis.products.Extract)
+    - [ExtractFlag](#opencannabis.products.ExtractFlag)
+    - [ExtractType](#opencannabis.products.ExtractType)
+    - [DistributionPolicy](#opencannabis.products.distribution.DistributionPolicy)
+    - [Channel](#opencannabis.products.distribution.Channel)
+    - [ChannelType](#opencannabis.products.distribution.ChannelType)
+    - [Cartridge](#opencannabis.products.Cartridge)
+    - [CartridgeType](#opencannabis.products.CartridgeType)
+    - [Plant](#opencannabis.products.Plant)
+    - [PlantType](#opencannabis.products.PlantType)
+    - [Preroll](#opencannabis.products.Preroll)
+    - [PrerollFlag](#opencannabis.products.PrerollFlag)
+
+
 ----
 
 ## `opencannabis.base`

--- a/3/3-Core-Structures.md
+++ b/3/3-Core-Structures.md
@@ -1259,6 +1259,22 @@ Specifies and enumerates products in the menu; flowers, extracts, edibles, apoth
 
 {% endnomnoml %}
 
+{% nomnoml %}
+
+
+#fill: #d5e7ee; #8ebff2
+[MenuProduct
+  | key:opencannabis.base.ProductKey
+  | apothecary:opencannabis.products.Apothecary
+  | cartridge:opencannabis.products.Cartridge
+  | edible:opencannabis.products.Edible
+  | extract:opencannabis.products.Extract
+  | flower:opencannabis.products.Flower
+  | merchandise:opencannabis.products.Merchandise
+  | plant:opencannabis.products.Plant
+  | preroll:opencannabis.products.Preroll]
+
+{% endnomnoml %}
 
 <p align="right"><a href="#top">Top</a></p>
 <a name="products/Merchandise.proto"/>
@@ -1578,3 +1594,21 @@ Specifies flags that may be specifically applied to pre-rolled cannabis products
 | FORTIFIED | 3 | Specifies that this pre-rolled item is fortified with extracted cannabis products in some manner. |
 | FULL_FLOWER | 4 | Specifies that this pre-rolled item is rolled with &#34;full flower&#34; buds, rather than trimmings, or other discarded cannabis from other production processes. |
 | CONTAINS_TOBACCO | 5 | Specifies that this product contains tobacco. |
+
+<p align="right"><a href="#top">Top</a></p>
+<a name="opencannabis.products.menu.MenuProduct"/>
+
+### MenuProduct
+Menu product payload stanza. Specifies a single product as a member of a menu section.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [opencannabis.base.ProductKey](#opencannabis.base.ProductKey) |  | Section that this data is attached to. |
+| apothecary | [opencannabis.products.Apothecary](#opencannabis.products.Apothecary) |  | Apothecary product. |
+| cartridge | [opencannabis.products.Cartridge](#opencannabis.products.Cartridge) |  | Cartridge product. |
+| edible | [opencannabis.products.Edible](#opencannabis.products.Edible) |  | Edible product. |
+| extract | [opencannabis.products.Extract](#opencannabis.products.Extract) |  | Extract product. |
+| flower | [opencannabis.products.Flower](#opencannabis.products.Flower) |  | Flower product. |
+| merchandise | [opencannabis.products.Merchandise](#opencannabis.products.Merchandise) |  | Merchandise product. |
+| plant | [opencannabis.products.Plant](#opencannabis.products.Plant) |  | Plant product. |
+| preroll | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  | Preroll product. |

--- a/3/4-Extension-Structures.md
+++ b/3/4-Extension-Structures.md
@@ -10,12 +10,13 @@ Definitions considered core to the main specification are enumerated separately 
 
 ## Table of Contents
 - [4/OCS-M](../4/README.md) / `media`: Images, video, documents, etc.
-- `labtesting`: Laboratory testing and QA.
-- `pricing`: Pricing schemes and structures.
-- `proximity`: Bluetooth and GPS-related structures.
-- `oauth`: OAuth2 implementation structures.
-- `commerce`: Commercial ordering and fulfillment structures.
-- `accounting`: Bookkeeping, accounting, taxes, and so on.
+- [5/OCS-N](../5/README.md) / `menu` : Distribution channels, product labels, product types, etc.
+- [6/OCS-C](../6/README.md) / `commerce`: Commercial ordering and fulfillment structures.
+- [7/OCS-L](../7/README.md) / `labtesting`: Laboratory testing and QA.
+- [8/OCS-P](../8/README.md) / `pricing`: Pricing schemes and structures.
+- [9/OCS-X](../9/README.md) / `proximity`: Bluetooth and GPS-related structures.
+- [10/OCS-O](../10/README.md) / `oauth`: OAuth2 implementation structures.
+- [11/OCS-A](../11/README.md) / `accounting`: Bookkeeping, accounting, taxes, and so on.
 
 ----
 

--- a/4/README.md
+++ b/4/README.md
@@ -210,8 +210,8 @@ Specifies video type information.
 | kind | [VideoType.VideoKind](#opencannabis.media.VideoType.VideoKind) |  | Specifies the kind of video being attached or described. |
 
 
-<a name="opencannabis.media.DocumentType.DocumentKind"/>
 <p align="right"><a href="#top">Top</a></p>
+<a name="opencannabis.media.DocumentType.DocumentKind"/>
 
 ### `DocumentType.DocumentKind.Number`
 Specifies kinds of documents that may be attached or described.
@@ -239,8 +239,8 @@ Specifies kinds of images that may be attached or described.
 | WEBP | 4 | WEBP image. |
 
 
-<a name="opencannabis.media.MediaType.Kind"/>
 <p align="right"><a href="#top">Top</a></p>
+<a name="opencannabis.media.MediaType.Kind"/>
 
 ### `MediaType.Kind.Number`
 Enumerates, in generic terms, the kinds of media that can be attached or described.
@@ -253,8 +253,8 @@ Enumerates, in generic terms, the kinds of media that can be attached or describ
 | VIDEO | 3 | Video data. |
 
 
-<a name="opencannabis.media.VideoType.VideoKind"/>
 <p align="right"><a href="#top">Top</a></p>
+<a name="opencannabis.media.VideoType.VideoKind"/>
 
 ### `VideoType.VideoKind.Number`
 Specifies kinds of videos that may be attached or described.
@@ -266,8 +266,8 @@ Specifies kinds of videos that may be attached or described.
 | HLS | 2 | HTTP Live Streaming video. |
 
 
-<a name="media/MediaItem.proto"/>
 <p align="right"><a href="#top">Top</a></p>
+<a name="media/MediaItem.proto"/>
 
 ### `MediaItem.Type`
 Describes an individual media item, which can be an image, video, etc.

--- a/5/README.md
+++ b/5/README.md
@@ -95,6 +95,11 @@ Specifies a menu, menu data structure, contents, products and so on
   | published:opencannabis.temporal.Instant
   | settings:MenuSettings]
 
+{% endnomnoml %}
+
+{% nomnoml %}
+
+#fill: #d5e7ee; #8ebff2
 [SectionData
   | count:int32
   | section:section.SectionSpec
@@ -104,6 +109,11 @@ Specifies a menu, menu data structure, contents, products and so on
   | count:int32
   | payload:SectionData]
 
+{% endnomnoml %}
+
+{% nomnoml %}
+
+#fill: #d5e7ee; #8ebff2
 [StaticMenu
   | apothecary:StaticMenu.ApothecaryEntry
   | cartridges:StaticMenu.CartridgesEntry
@@ -126,6 +136,11 @@ Specifies a menu, menu data structure, contents, products and so on
   | key:string
   | value:opencannabis.products.Edible]
 
+{% endnomnoml %}
+
+{% nomnoml %}
+
+#fill: #d5e7ee; #8ebff2
 [StaticMenu.ExtractsEntry
   | key:string
   | value:opencannabis.products.Extract]
@@ -133,6 +148,7 @@ Specifies a menu, menu data structure, contents, products and so on
 [StaticMenu.FlowersEntry
   | key:string
   | value:opencannabis.products.Flower]
+
 
 [StaticMenu.MerchandiseEntry
   | key:string
@@ -146,6 +162,12 @@ Specifies a menu, menu data structure, contents, products and so on
   | key:string
   | value:opencannabis.products.Preroll]
 
+
+{% endnomnoml %}
+
+{% nomnoml %}
+
+#fill: #d5e7ee; #8ebff2
 [Flag
   | DRAFT:0
   | PRIVATE:1
@@ -157,13 +179,8 @@ Specifies a menu, menu data structure, contents, products and so on
 
 {% endnomnoml %}
 
-<a name="products/menu/Menu.proto"/>
 <p align="right"><a href="#top">Top</a></p>
-
-## products/menu/Menu.proto
-
-
-<a name="opencannabis.products.menu.Menu"/>
+<a name="products/menu/Menu.proto"/>
 
 ### Menu
 Holds a full specification for a revision of menu data, segmented into sections, by the categories member products
@@ -194,6 +211,7 @@ Menu product payload stanza. Specifies a single product as a member of a menu se
 | preroll | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  | Preroll product. |
 
 
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.MenuSettings"/>
 
 ### MenuSettings
@@ -208,6 +226,7 @@ Specifies settings used to generate a menu, or used as input when generating men
 | section | [section.Section](#opencannabis.products.menu.section.Section) | repeated | Sections to include in the menu. If unspecified, include all sections. |
 
 
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.Metadata"/>
 
 ### Metadata
@@ -223,6 +242,7 @@ Specifies metadata for a package of menu data.
 | settings | [MenuSettings](#opencannabis.products.menu.MenuSettings) |  | Settings that produced this menu data. |
 
 
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.SectionData"/>
 
 ### SectionData
@@ -246,6 +266,7 @@ Specifies a menu split into section-level chunks.
 | payload | [SectionData](#opencannabis.products.menu.SectionData) | repeated | Specifies a payload of sectioned menu data. |
 
 
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.StaticMenu"/>
 
 ### StaticMenu
@@ -348,6 +369,7 @@ each map value is itself a product, and each map is addressed at a typed propert
 | value | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  |  |
 
 
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.Flag"/>
 
 ### Flag
@@ -359,7 +381,7 @@ Enumerates flags that can be set on a menu.
 | PRIVATE | 1 | Indicates that the underlying menu data is currently private and should not be exposed publicly. |
 | OUT_OF_DATE | 2 | Indicates that the underlying menu data is known to be out-of-date. |
 
-
+<p align="right"><a href="#top">Top</a></p>
 <a name="opencannabis.products.menu.Status"/>
 
 ### Status

--- a/5/README.md
+++ b/5/README.md
@@ -1,0 +1,371 @@
+---
+domain: rfc.opencannabis.info
+shortname: 5/OCS-N
+name: OpenCannabis Menu Extension
+status: raw
+editor: Randal Stevens <randy@bloombox.io>
+contributors:
+- Sam Gammon <sam@bloombox.io>
+---
+
+# OpenCannabis: Menu Extension
+- Version `1.0`
+- Status: `RAW`
+
+### Status of this Memo
+
+This specification's current status is considered `RAW`, i.e. pre-`DRAFT`. Distribution of this memo is unlimited.
+
+### Abstract
+
+This document describes an extension to the _OpenCannabis Specification, version 1_, that introduces menu-
+related definitions structures, and services that compose, create .
+
+_"Menu"_ in this context, refers to:
+- The contents of a dispensaries products
+- The product categories and their respective names
+- The status of the "Menu"
+- The channel through which the "Menu" is displayed to customers
+
+
+### Table of Contents
+- [Protocol Definition](#Protocol-Definition): `Menu`: distribution channels, product labels, product types, etc.
+    - [CustomSection](#opencannabis.products.menu.section.CustomSection)
+    - [SectionMedia](#opencannabis.products.menu.section.SectionMedia)
+    - [SectionSettings](#opencannabis.products.menu.section.SectionSettings)
+    - [SectionSpec](#opencannabis.products.menu.section.SectionSpec)
+    - [FilteredSection](#opencannabis.products.menu.section.FilteredSection)
+    - [Section](#opencannabis.products.menu.section.Section)
+    - [SectionFlag](#opencannabis.products.menu.section.SectionFlag)
+    - [Menu](#opencannabis.products.menu.Menu)
+    - [MenuProduct](#opencannabis.products.menu.MenuProduct)
+    - [MenuSettings](#opencannabis.products.menu.MenuSettings)
+    - [Metadata](#opencannabis.products.menu.Metadata)
+    - [SectionData](#opencannabis.products.menu.SectionData)
+    - [SectionedMenu](#opencannabis.products.menu.SectionedMenu)
+    - [StaticMenu](#opencannabis.products.menu.StaticMenu)
+    - [StaticMenu.ApothecaryEntry](#opencannabis.products.menu.StaticMenu.ApothecaryEntry)
+    - [StaticMenu.CartridgesEntry](#opencannabis.products.menu.StaticMenu.CartridgesEntry)
+    - [StaticMenu.EdiblesEntry](#opencannabis.products.menu.StaticMenu.EdiblesEntry)
+    - [StaticMenu.ExtractsEntry](#opencannabis.products.menu.StaticMenu.ExtractsEntry)
+    - [StaticMenu.FlowersEntry](#opencannabis.products.menu.StaticMenu.FlowersEntry)
+    - [StaticMenu.MerchandiseEntry](#opencannabis.products.menu.StaticMenu.MerchandiseEntry)
+    - [StaticMenu.PlantsEntry](#opencannabis.products.menu.StaticMenu.PlantsEntry)
+    - [StaticMenu.PrerollsEntry](#opencannabis.products.menu.StaticMenu.PrerollsEntry)
+
+
+----
+
+## Protocol Definition
+### `opencannabis.menu`
+Specifies a menu, menu data structure, contents, products and so on
+
+{% nomnoml %}
+
+#fill: #d5e7ee; #8ebff2
+
+[Menu
+  | metadata:Metadata
+  | payload:SectionedMenu
+  | menu:StaticMenu]
+
+[MenuProduct
+  | key:opencannabis.base.ProductKey
+  | apothecary:opencannabis.products.Apothecary
+  | cartridge:opencannabis.products.Cartridge
+  | edible:opencannabis.products.Edible
+  | extract:opencannabis.products.Extract
+  | flower:opencannabis.products.Flower
+  | merchandise:opencannabis.products.Merchandise
+  | plant:opencannabis.products.Plant
+  | preroll:opencannabis.products.Preroll]
+
+[MenuSettings
+  | full:bool
+  | keys_only:bool
+  | snapshot:opencannabis.crypto.primitives.integrity.Hash
+  | fingerprint:opencannabis.crypto.primitives.integrity.Hash
+  | section:section.Section]
+
+[Metadata
+  | scope:string
+  | version:uint64
+  | status:Status
+  | flags:Flag
+  | published:opencannabis.temporal.Instant
+  | settings:MenuSettings]
+
+[SectionData
+  | count:int32
+  | section:section.SectionSpec
+  | product:MenuProduct]
+
+[SectionedMenu
+  | count:int32
+  | payload:SectionData]
+
+[StaticMenu
+  | apothecary:StaticMenu.ApothecaryEntry
+  | cartridges:StaticMenu.CartridgesEntry
+  | edibles:StaticMenu.EdiblesEntry
+  | extracts:StaticMenu.ExtractsEntry
+  | flowers:StaticMenu.FlowersEntry
+  | merchandise:StaticMenu.MerchandiseEntry
+  | plants:StaticMenu.PlantsEntry
+  | prerolls:StaticMenu.PrerollsEntry]
+
+[StaticMenu.ApothecaryEntry
+  | key:string
+  | value:opencannabis.products.Apothecary]
+
+[StaticMenu.CartridgesEntry
+  | key:string
+  | value:opencannabis.products.Cartridge]
+
+[StaticMenu.EdiblesEntry
+  | key:string
+  | value:opencannabis.products.Edible]
+
+[StaticMenu.ExtractsEntry
+  | key:string
+  | value:opencannabis.products.Extract]
+
+[StaticMenu.FlowersEntry
+  | key:string
+  | value:opencannabis.products.Flower]
+
+[StaticMenu.MerchandiseEntry
+  | key:string
+  | value:opencannabis.products.Merchandise]
+
+[StaticMenu.PrerollsEntry
+  | key:string
+  | value:opencannabis.products.Plant]
+
+[StaticMenu.PrerollsEntry
+  | key:string
+  | value:opencannabis.products.Preroll]
+
+[Flag
+  | DRAFT:0
+  | PRIVATE:1
+  | OUT_OF_DATE:2]
+
+[Status
+  | UNPUBLISHED:0
+  | LIVE:1]
+
+{% endnomnoml %}
+
+<a name="products/menu/Menu.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## products/menu/Menu.proto
+
+
+<a name="opencannabis.products.menu.Menu"/>
+
+### Menu
+Holds a full specification for a revision of menu data, segmented into sections, by the categories member products
+are filed in. Categories are enumerated in `menu.Section`.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| metadata | [Metadata](#opencannabis.products.menu.Metadata) |  | Metadata for the menu. |
+| payload | [SectionedMenu](#opencannabis.products.menu.SectionedMenu) |  | Data payloads attached to this menu. |
+| menu | [StaticMenu](#opencannabis.products.menu.StaticMenu) |  | Specifies a static menu, where each section is specified as a typed map, with keys mapped to products. |
+
+
+<a name="opencannabis.products.menu.MenuProduct"/>
+
+### MenuProduct
+Menu product payload stanza. Specifies a single product as a member of a menu section.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [opencannabis.base.ProductKey](#opencannabis.base.ProductKey) |  | Section that this data is attached to. |
+| apothecary | [opencannabis.products.Apothecary](#opencannabis.products.Apothecary) |  | Apothecary product. |
+| cartridge | [opencannabis.products.Cartridge](#opencannabis.products.Cartridge) |  | Cartridge product. |
+| edible | [opencannabis.products.Edible](#opencannabis.products.Edible) |  | Edible product. |
+| extract | [opencannabis.products.Extract](#opencannabis.products.Extract) |  | Extract product. |
+| flower | [opencannabis.products.Flower](#opencannabis.products.Flower) |  | Flower product. |
+| merchandise | [opencannabis.products.Merchandise](#opencannabis.products.Merchandise) |  | Merchandise product. |
+| plant | [opencannabis.products.Plant](#opencannabis.products.Plant) |  | Plant product. |
+| preroll | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  | Preroll product. |
+
+
+<a name="opencannabis.products.menu.MenuSettings"/>
+
+### MenuSettings
+Specifies settings used to generate a menu, or used as input when generating menus.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| full | [bool](#bool) |  | Flag indicating a full menu, including hidden/out-of-stock items. |
+| keys_only | [bool](#bool) |  | Only include menu keys, no detail data. |
+| snapshot | [opencannabis.crypto.primitives.integrity.Hash](#opencannabis.crypto.primitives.integrity.Hash) |  | Don&#39;t return the menu if it&#39;s identical to this fingerprint. |
+| fingerprint | [opencannabis.crypto.primitives.integrity.Hash](#opencannabis.crypto.primitives.integrity.Hash) |  | Bloom filter to consider when returning or processing menu items. |
+| section | [section.Section](#opencannabis.products.menu.section.Section) | repeated | Sections to include in the menu. If unspecified, include all sections. |
+
+
+<a name="opencannabis.products.menu.Metadata"/>
+
+### Metadata
+Specifies metadata for a package of menu data.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| scope | [string](#string) |  | Partner location that owns this menu data. |
+| version | [uint64](#uint64) |  | Version number, or publish timestamp, of this data. |
+| status | [Status](#opencannabis.products.menu.Status) |  | Status of this menu data. |
+| flags | [Flag](#opencannabis.products.menu.Flag) | repeated | Flags attached to this menu data. |
+| published | [opencannabis.temporal.Instant](#opencannabis.temporal.Instant) |  | When this menu data was published. |
+| settings | [MenuSettings](#opencannabis.products.menu.MenuSettings) |  | Settings that produced this menu data. |
+
+
+<a name="opencannabis.products.menu.SectionData"/>
+
+### SectionData
+Specifies an inner menu payload which contains menu data for a given menu section.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int32](#int32) |  | Count of products included in this menu section data. |
+| section | [section.SectionSpec](#opencannabis.products.menu.section.SectionSpec) |  | Section that this data is attached to. |
+| product | [MenuProduct](#opencannabis.products.menu.MenuProduct) | repeated | Menu products attached to this section. |
+
+
+<a name="opencannabis.products.menu.SectionedMenu"/>
+
+### SectionedMenu
+Specifies a menu split into section-level chunks.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int32](#int32) |  | Count of all products included in this menu, all sections considered. |
+| payload | [SectionData](#opencannabis.products.menu.SectionData) | repeated | Specifies a payload of sectioned menu data. |
+
+
+<a name="opencannabis.products.menu.StaticMenu"/>
+
+### StaticMenu
+Specifies an inner menu payload which contains mapped data, where each map key is a section name, lowercased, and
+each map value is itself a product, and each map is addressed at a typed property name.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| apothecary | [StaticMenu.ApothecaryEntry](#opencannabis.products.menu.StaticMenu.ApothecaryEntry) | repeated | Specifies APOTHECARY products attached to this menu. |
+| cartridges | [StaticMenu.CartridgesEntry](#opencannabis.products.menu.StaticMenu.CartridgesEntry) | repeated | Specifies CARTRIDGE products attached to this menu. |
+| edibles | [StaticMenu.EdiblesEntry](#opencannabis.products.menu.StaticMenu.EdiblesEntry) | repeated | Specifies EDIBLE products attached to this menu. |
+| extracts | [StaticMenu.ExtractsEntry](#opencannabis.products.menu.StaticMenu.ExtractsEntry) | repeated | Specifies EXTRACT products attached to this menu. |
+| flowers | [StaticMenu.FlowersEntry](#opencannabis.products.menu.StaticMenu.FlowersEntry) | repeated | Specifies FLOWER products attached to this menu. |
+| merchandise | [StaticMenu.MerchandiseEntry](#opencannabis.products.menu.StaticMenu.MerchandiseEntry) | repeated | Specifies MERCHANDISE products attached to this menu. |
+| plants | [StaticMenu.PlantsEntry](#opencannabis.products.menu.StaticMenu.PlantsEntry) | repeated | Specifies PLANT products attached to this menu. |
+| prerolls | [StaticMenu.PrerollsEntry](#opencannabis.products.menu.StaticMenu.PrerollsEntry) | repeated | Specifies PREROLL products attached to this menu. |
+
+
+<a name="opencannabis.products.menu.StaticMenu.ApothecaryEntry"/>
+
+### StaticMenu.ApothecaryEntry
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Apothecary](#opencannabis.products.Apothecary) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.CartridgesEntry"/>
+
+### StaticMenu.CartridgesEntry
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Cartridge](#opencannabis.products.Cartridge) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.EdiblesEntry"/>
+
+### StaticMenu.EdiblesEntry
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Edible](#opencannabis.products.Edible) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.ExtractsEntry"/>
+
+### StaticMenu.ExtractsEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Extract](#opencannabis.products.Extract) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.FlowersEntry"/>
+
+### StaticMenu.FlowersEntry
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Flower](#opencannabis.products.Flower) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.MerchandiseEntry"/>
+
+### StaticMenu.MerchandiseEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Merchandise](#opencannabis.products.Merchandise) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.PlantsEntry"/>
+
+### StaticMenu.PlantsEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Plant](#opencannabis.products.Plant) |  |  |
+
+
+<a name="opencannabis.products.menu.StaticMenu.PrerollsEntry"/>
+
+### StaticMenu.PrerollsEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  |  |
+
+
+<a name="opencannabis.products.menu.Flag"/>
+
+### Flag
+Enumerates flags that can be set on a menu.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| DRAFT | 0 | Indicates that this entire menu is considered a draft. |
+| PRIVATE | 1 | Indicates that the underlying menu data is currently private and should not be exposed publicly. |
+| OUT_OF_DATE | 2 | Indicates that the underlying menu data is known to be out-of-date. |
+
+
+<a name="opencannabis.products.menu.Status"/>
+
+### Status
+Enumerates statuses a menu may assume.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNPUBLISHED | 0 | Indicates that a menu revision is not yet published. |
+| LIVE | 1 | Indicates that a menu revision has been published and is considered live. |

--- a/5/README.md
+++ b/5/README.md
@@ -29,7 +29,7 @@ _"Menu"_ in this context, refers to:
 
 
 ### Table of Contents
-- [Protocol Definition](#Protocol-Definition): `Menu`: distribution channels, product labels, product types, etc.
+- [Protocol Definition](#Protocol-Definition): `Menu`: Distribution channels, product labels, product types, etc.
     - [CustomSection](#opencannabis.products.menu.section.CustomSection)
     - [SectionMedia](#opencannabis.products.menu.section.SectionMedia)
     - [SectionSettings](#opencannabis.products.menu.section.SectionSettings)

--- a/5/README.md
+++ b/5/README.md
@@ -69,17 +69,6 @@ Specifies a menu, menu data structure, contents, products and so on.
   | payload:SectionedMenu
   | menu:StaticMenu]
 
-[MenuProduct
-  | key:opencannabis.base.ProductKey
-  | apothecary:opencannabis.products.Apothecary
-  | cartridge:opencannabis.products.Cartridge
-  | edible:opencannabis.products.Edible
-  | extract:opencannabis.products.Extract
-  | flower:opencannabis.products.Flower
-  | merchandise:opencannabis.products.Merchandise
-  | plant:opencannabis.products.Plant
-  | preroll:opencannabis.products.Preroll]
-
 [MenuSettings
   | full:bool
   | keys_only:bool
@@ -191,24 +180,6 @@ are filed in. Categories are enumerated in `menu.Section`.
 | metadata | [Metadata](#opencannabis.products.menu.Metadata) |  | Metadata for the menu. |
 | payload | [SectionedMenu](#opencannabis.products.menu.SectionedMenu) |  | Data payloads attached to this menu. |
 | menu | [StaticMenu](#opencannabis.products.menu.StaticMenu) |  | Specifies a static menu, where each section is specified as a typed map, with keys mapped to products. |
-
-
-<a name="opencannabis.products.menu.MenuProduct"/>
-
-### MenuProduct
-Menu product payload stanza. Specifies a single product as a member of a menu section.
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [opencannabis.base.ProductKey](#opencannabis.base.ProductKey) |  | Section that this data is attached to. |
-| apothecary | [opencannabis.products.Apothecary](#opencannabis.products.Apothecary) |  | Apothecary product. |
-| cartridge | [opencannabis.products.Cartridge](#opencannabis.products.Cartridge) |  | Cartridge product. |
-| edible | [opencannabis.products.Edible](#opencannabis.products.Edible) |  | Edible product. |
-| extract | [opencannabis.products.Extract](#opencannabis.products.Extract) |  | Extract product. |
-| flower | [opencannabis.products.Flower](#opencannabis.products.Flower) |  | Flower product. |
-| merchandise | [opencannabis.products.Merchandise](#opencannabis.products.Merchandise) |  | Merchandise product. |
-| plant | [opencannabis.products.Plant](#opencannabis.products.Plant) |  | Plant product. |
-| preroll | [opencannabis.products.Preroll](#opencannabis.products.Preroll) |  | Preroll product. |
 
 
 <p align="right"><a href="#top">Top</a></p>

--- a/5/README.md
+++ b/5/README.md
@@ -19,7 +19,7 @@ This specification's current status is considered `RAW`, i.e. pre-`DRAFT`. Distr
 ### Abstract
 
 This document describes an extension to the _OpenCannabis Specification, version 1_, that introduces menu-
-related definitions structures, and services that compose, create .
+related definitions structures, and services that compose, create and reference menus.
 
 _"Menu"_ in this context, refers to:
 - The contents of a dispensaries products
@@ -58,7 +58,7 @@ _"Menu"_ in this context, refers to:
 
 ## Protocol Definition
 ### `opencannabis.menu`
-Specifies a menu, menu data structure, contents, products and so on
+Specifies a menu, menu data structure, contents, products and so on.
 
 {% nomnoml %}
 


### PR DESCRIPTION
### Description
This changeset adds `5/OCS-N`, which defines an extension to the core _OpenCannabis Specification_ to provide structures that express menus of concrete products.

### Changelog
- [x] Early menu extension proposal
- [x] All menu docs and structures moved over
- [x] All menu structures documented
- [x] Review
  - [x] Retail WG (@OpenCannabis/retail)
  - [x] Technology WG (@OpenCannabis/technology)
