### PR TITLE
 Fix 'Top' linking issue 

### DIFF
--- a/3/4-Extension-Structures.md
+++ b/3/4-Extension-Structures.md
@@ -161,8 +161,8 @@ Full menu structures and payloads.
 {% endnomnoml %}
 
 
-<p align="right"><a href="#top">Top</a></p>
 <a name="products/menu/Section.proto"/>
+<p align="right"><a href="#top">Top</a></p>
 
 ### `CustomSection.Type`
 Custom configuration-based menu sections, usually via `FilteredSection`.
@@ -249,8 +249,8 @@ Flags that may be applied to a section&#39;s configuration.
 | FEATURED | 1 | This section should be promoted and/or presented with high priority. |
 
 
-<p align="right"><a href="#top">Top</a></p>
 <a name="products/menu/Menu.proto"/>
+<p align="right"><a href="#top">Top</a></p>
 
 ### `Menu.Type`
 Holds a full specification for a revision of menu data, segmented into sections, by the categories member products

--- a/3/4-Extension-Structures.md
+++ b/3/4-Extension-Structures.md
@@ -426,7 +426,6 @@ each map value is itself a product, and each map is addressed at a typed propert
 
 ### `StaticMenu.PrerollsEntry.Type`
 
-
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | key | [string](#string) |  |  |


### PR DESCRIPTION
### Description

Links to bring you to the top of the page can be tough to
format properly. I fixed these ones.
